### PR TITLE
Add timestamped hexacle hashes to enrichment pipeline

### DIFF
--- a/backend/db/migrations/017_add_temps_hexacle_hash.up.sql
+++ b/backend/db/migrations/017_add_temps_hexacle_hash.up.sql
@@ -1,0 +1,10 @@
+-- Add support for timestamp-based hexacle hashes in enrichment workflow tables
+ALTER TABLE temp_reference_data
+ADD COLUMN temps_hexacle_hash VARCHAR(255) NOT NULL DEFAULT '';
+
+CREATE INDEX idx_temp_reference_data_temps_hexacle_hash ON temp_reference_data(temps_hexacle_hash);
+
+ALTER TABLE enrichment_results
+ADD COLUMN temps_hexacle_hash VARCHAR(255) NOT NULL DEFAULT '';
+
+CREATE INDEX idx_enrichment_results_temps_hexacle_hash ON enrichment_results(temps_hexacle_hash);


### PR DESCRIPTION
## Summary
- add a migration that introduces the `temps_hexacle_hash` column and supporting indexes on the enrichment workflow tables
- compute the timestamp-based hash when loading temp reference data and persist it through enrichment results
- expose the new hash in the generated CSV export

## Testing
- npx tsc --noEmit *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68cd84fc41c4832c9c2ccb8001fec9ff