### PR TITLE
Refactor CSV enrichment import pipeline

### DIFF
--- a/backend/enrichment/__tests__/importer.test.ts
+++ b/backend/enrichment/__tests__/importer.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseMapping,
+  mapCsvRowToImportRecord,
+  MappingError,
+  hasMappedValue,
+} from "../importer";
+
+describe("parseMapping", () => {
+  test("normalizes supported destination columns", () => {
+    const mapping = parseMapping(
+      JSON.stringify({
+        HEXACLE: "Hexacle",
+        Numero: "NUMERO",
+        City: "ville",
+        Unknown: "IGNORED",
+      }),
+    );
+
+    expect(Array.from(mapping.entries())).toEqual([
+      ["hexacle", "HEXACLE"],
+      ["numero", "Numero"],
+      ["ville", "City"],
+    ]);
+  });
+
+  test("throws a mapping error when JSON is invalid", () => {
+    expect(() => parseMapping("not-json")).toThrow(MappingError);
+  });
+
+  test("throws a mapping error when no supported columns are provided", () => {
+    expect(() =>
+      parseMapping(
+        JSON.stringify({
+          foo: "bar",
+        }),
+      ),
+    ).toThrow(MappingError);
+  });
+});
+
+describe("mapCsvRowToImportRecord", () => {
+  test("returns a sanitized import record", () => {
+    const mapping = parseMapping(
+      JSON.stringify({
+        HEXACLE: "Hexacle",
+        Numero: "NUMERO",
+        Rue: "VOIE",
+        City: "ville",
+        Postal: "cod_post",
+        Insee: "COD_INSEE",
+      }),
+    );
+
+    const record = mapCsvRowToImportRecord(
+      {
+        HEXACLE: " 123 ",
+        Numero: 7,
+        Rue: " Av. de la République ",
+        City: "Paris",
+        Postal: "",
+        Insee: null,
+      },
+      mapping,
+      99,
+    );
+
+    expect(record).toEqual({
+      source_id: "99",
+      hexacle: "123",
+      numero: "7",
+      voie: "Av. de la République",
+      ville: "Paris",
+      cod_post: null,
+      cod_insee: null,
+    });
+  });
+
+  test("identifies when a record has no mapped values", () => {
+    const mapping = parseMapping(
+      JSON.stringify({
+        HEXACLE: "Hexacle",
+      }),
+    );
+
+    const record = mapCsvRowToImportRecord(
+      {
+        HEXACLE: "   ",
+      },
+      mapping,
+      1,
+    );
+
+    expect(hasMappedValue(record, mapping)).toBe(false);
+  });
+});

--- a/backend/enrichment/importer.ts
+++ b/backend/enrichment/importer.ts
@@ -1,0 +1,146 @@
+import type { EnrichmentSource } from "../settings/types";
+
+export type ImportColumn =
+  | "hexacle"
+  | "numero"
+  | "voie"
+  | "ville"
+  | "cod_post"
+  | "cod_insee";
+
+const SUPPORTED_COLUMNS: ReadonlySet<ImportColumn> = new Set([
+  "hexacle",
+  "numero",
+  "voie",
+  "ville",
+  "cod_post",
+  "cod_insee",
+]);
+
+export interface ImportRecord {
+  source_id: string;
+  hexacle: string | null;
+  numero: string | null;
+  voie: string | null;
+  ville: string | null;
+  cod_post: string | null;
+  cod_insee: string | null;
+}
+
+export class MappingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MappingError";
+  }
+}
+
+export type SourceRow = Pick<EnrichmentSource, "id" | "name" | "filePath" | "hasHeaders" | "delimiter"> & {
+  mapping: string;
+};
+
+export function parseMapping(mappingJson: string): Map<ImportColumn, string> {
+  if (!mappingJson || mappingJson.trim().length === 0) {
+    throw new MappingError("Mapping configuration is empty.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(mappingJson);
+  } catch {
+    throw new MappingError("Mapping configuration is not valid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new MappingError("Mapping configuration must be an object.");
+  }
+
+  const mapping = new Map<ImportColumn, string>();
+  for (const [sourceColumn, destinationColumn] of Object.entries(
+    parsed as Record<string, unknown>,
+  )) {
+    if (typeof destinationColumn !== "string" || destinationColumn.trim().length === 0) {
+      throw new MappingError(`Invalid destination column for source "${sourceColumn}".`);
+    }
+
+    const normalizedDestination = normalizeColumnKey(destinationColumn);
+    if (!isSupportedColumn(normalizedDestination)) {
+      continue;
+    }
+
+    mapping.set(normalizedDestination, sourceColumn.trim());
+  }
+
+  if (mapping.size === 0) {
+    throw new MappingError(
+      "Mapping configuration does not contain any supported destination columns.",
+    );
+  }
+
+  return mapping;
+}
+
+export function mapCsvRowToImportRecord(
+  row: Record<string, unknown>,
+  mapping: Map<ImportColumn, string>,
+  sourceId: number | string,
+): ImportRecord {
+  const lookup = buildLookup(row);
+
+  const record: ImportRecord = {
+    source_id: String(sourceId),
+    hexacle: null,
+    numero: null,
+    voie: null,
+    ville: null,
+    cod_post: null,
+    cod_insee: null,
+  };
+
+  for (const [destination, sourceColumn] of mapping.entries()) {
+    const value = lookup.get(normalizeColumnKey(sourceColumn));
+    record[destination] = normalizeValue(value);
+  }
+
+  return record;
+}
+
+function buildLookup(row: Record<string, unknown>): Map<string, unknown> {
+  const lookup = new Map<string, unknown>();
+
+  for (const [key, value] of Object.entries(row)) {
+    if (typeof key !== "string") continue;
+    lookup.set(normalizeColumnKey(key), value);
+  }
+
+  return lookup;
+}
+
+function normalizeValue(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  }
+
+  return String(value);
+}
+
+function normalizeColumnKey(column: string): ImportColumn | string {
+  return column.trim().toLowerCase();
+}
+
+function isSupportedColumn(column: string): column is ImportColumn {
+  return SUPPORTED_COLUMNS.has(column as ImportColumn);
+}
+
+export function hasMappedValue(record: ImportRecord, mapping: Map<ImportColumn, string>): boolean {
+  for (const destination of mapping.keys()) {
+    if (record[destination] !== null) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/backend/enrichment/process.ts
+++ b/backend/enrichment/process.ts
@@ -1,98 +1,172 @@
 import { api, APIError } from "encore.dev/api";
-import type { StartImportRequest, StartImportResponse } from "./types";
-import type { EnrichmentSource } from "../settings/types";
-import { v4 as uuidv4 } from "uuid";
-import fs from "fs";
+import { createReadStream } from "fs";
 import csv from "csv-parser";
+import { v4 as uuidv4 } from "uuid";
+
 import { enrichmentDB as db } from "./db";
+import type { StartImportRequest, StartImportResponse } from "./types";
+import {
+  parseMapping,
+  mapCsvRowToImportRecord,
+  MappingError,
+  type ImportRecord,
+  type SourceRow,
+  hasMappedValue,
+} from "./importer";
 
 export const startImport = api<StartImportRequest, StartImportResponse>(
   { expose: true, method: "POST", path: "/enrichment/start-import" },
   async ({ sourceId }) => {
-    const jobId = uuidv4();
+    let jobId: string | null = null;
     let recordsProcessed = 0;
+    let jobCreated = false;
 
     try {
-      const source = await db.queryRow<EnrichmentSource & { mapping: string }>`
-        SELECT id, name, file_path as "filePath", has_headers as "hasHeaders", delimiter, mapping
-        FROM enrichment_sources
-        WHERE id = ${sourceId}
-      `;
+      const source = await loadSource(sourceId);
 
-      if (!source) {
-        throw new Error("Source not found");
-      }
+      jobId = uuidv4();
+      await createJobHistory(jobId, sourceId, source.name);
+      jobCreated = true;
 
-      await db.exec`
-        INSERT INTO job_history (job_id, source_id, filename, status, file_type, created_by, started_at)
-        VALUES (${jobId}, ${sourceId}, ${source.name}, 'processing', 'enrichment_import', 'system', NOW())
-      `;
+      const mapping = parseMapping(source.mapping);
+      const stream = createCsvStream(source);
 
-      const mapping = JSON.parse(source.mapping) as Record<string, string>;
-      const reversedMapping = Object.fromEntries(Object.entries(mapping).map(([key, value]) => [value, key]));
+      let batch: ImportRecord[] = [];
 
-      const stream = fs.createReadStream(source.filePath).pipe(csv({
-        separator: source.delimiter,
-        headers: source.hasHeaders,
-        mapHeaders: ({ header }) => header.trim(),
-      }));
-
-      const batchSize = 100;
-      let batch: any[] = [];
-
-      for await (const row of stream) {
-        const importedRow: any = { source_id: sourceId };
-        for (const destCol in reversedMapping) {
-          const sourceCol = reversedMapping[destCol];
-          if (row[sourceCol]) {
-            importedRow[destCol.toLowerCase()] = row[sourceCol];
-          }
+      for await (const row of stream as AsyncIterable<Record<string, unknown>>) {
+        const record = mapCsvRowToImportRecord(row, mapping, sourceId);
+        if (!hasMappedValue(record, mapping)) {
+          continue;
         }
-        batch.push(importedRow);
 
-        if (batch.length >= batchSize) {
-          await insertBatch(batch);
-          recordsProcessed += batch.length;
-          await db.exec`UPDATE job_history SET records_processed = ${recordsProcessed} WHERE job_id = ${jobId}`;
+        batch.push(record);
+
+        if (batch.length >= BATCH_SIZE) {
+          recordsProcessed += await insertBatch(batch);
+          await updateRecordsProcessed(jobId, recordsProcessed);
           batch = [];
         }
       }
 
       if (batch.length > 0) {
-        await insertBatch(batch);
-        recordsProcessed += batch.length;
+        recordsProcessed += await insertBatch(batch);
+        await updateRecordsProcessed(jobId, recordsProcessed);
       }
 
-      await db.exec`
-        UPDATE job_history 
-        SET status = 'completed', records_processed = ${recordsProcessed}, completed_at = NOW()
-        WHERE job_id = ${jobId}
-      `;
+      await markJobCompleted(jobId, recordsProcessed);
 
       return { success: true, jobId, recordsProcessed };
+    } catch (error) {
+      if (jobCreated && jobId) {
+        await markJobFailed(jobId, error);
+      }
 
-    } catch (error: any) {
-      await db.exec`
-        UPDATE job_history
-        SET status = 'failed', error_message = ${error.message}, completed_at = NOW()
-        WHERE job_id = ${jobId}
-      `;
+      if (error instanceof MappingError) {
+        throw APIError.invalidArgument(error.message);
+      }
+
+      if (error instanceof APIError) {
+        throw error;
+      }
+
       throw APIError.internal("Failed to import data", error as Error);
     }
   }
 );
 
-async function insertBatch(batch: any[]) {
-  if (batch.length === 0) return;
+const BATCH_SIZE = 500;
 
-  for (const row of batch) {
-    try {
-      await db.exec`
-        INSERT INTO imported_data (source_id, hexacle, numero, voie, ville, cod_post, cod_insee)
-        VALUES (${row.source_id}, ${row.hexacle}, ${row.numero}, ${row.voie}, ${row.ville}, ${row.cod_post}, ${row.cod_insee})
-      `;
-    } catch (e: any) {
-      console.error(`Failed to insert row: ${JSON.stringify(row)}`, e.message);
-    }
+async function loadSource(sourceId: number): Promise<SourceRow> {
+  const source = await db.queryRow<SourceRow>`
+    SELECT id, name, file_path as "filePath", has_headers as "hasHeaders", delimiter, mapping
+    FROM enrichment_sources
+    WHERE id = ${sourceId}
+  `;
+
+  if (!source) {
+    throw APIError.notFound("Source not found");
   }
+
+  return source;
+}
+
+async function createJobHistory(jobId: string, sourceId: number, sourceName: string): Promise<void> {
+  await db.exec`
+    INSERT INTO job_history (job_id, source_id, filename, status, file_type, created_by, started_at)
+    VALUES (${jobId}, ${sourceId}, ${sourceName}, 'processing', 'enrichment_import', 'system', NOW())
+  `;
+}
+
+function createCsvStream(source: SourceRow) {
+  const readStream = createReadStream(source.filePath);
+  const parser = csv({
+    separator: source.delimiter && source.delimiter.length > 0 ? source.delimiter : ",",
+    headers: source.hasHeaders,
+    mapHeaders: ({ header, index }) => (header ? header.trim() : index.toString()),
+  });
+
+  readStream.on("error", (error) => {
+    parser.destroy(error);
+  });
+
+  return readStream.pipe(parser);
+}
+
+async function insertBatch(batch: ImportRecord[]): Promise<number> {
+  if (batch.length === 0) {
+    return 0;
+  }
+
+  const payload = JSON.stringify(
+    batch.map((row) => ({
+      source_id: row.source_id,
+      hexacle: row.hexacle,
+      numero: row.numero,
+      voie: row.voie,
+      ville: row.ville,
+      cod_post: row.cod_post,
+      cod_insee: row.cod_insee,
+    })),
+  );
+
+  await db.exec`
+    INSERT INTO imported_data (source_id, hexacle, numero, voie, ville, cod_post, cod_insee)
+    SELECT source_id, hexacle, numero, voie, ville, cod_post, cod_insee
+    FROM json_to_recordset(${payload}) AS t(
+      source_id text,
+      hexacle text,
+      numero text,
+      voie text,
+      ville text,
+      cod_post text,
+      cod_insee text
+    )
+  `;
+
+  return batch.length;
+}
+
+async function updateRecordsProcessed(jobId: string, recordsProcessed: number): Promise<void> {
+  await db.exec`
+    UPDATE job_history
+    SET records_processed = ${recordsProcessed}
+    WHERE job_id = ${jobId}
+  `;
+}
+
+async function markJobCompleted(jobId: string, recordsProcessed: number): Promise<void> {
+  await db.exec`
+    UPDATE job_history
+    SET status = 'completed', records_processed = ${recordsProcessed}, completed_at = NOW()
+    WHERE job_id = ${jobId}
+  `;
+}
+
+async function markJobFailed(jobId: string, error: unknown): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error);
+  await db.exec`
+    UPDATE job_history
+    SET status = 'failed', error_message = ${message}, completed_at = NOW()
+    WHERE job_id = ${jobId}
+  `;
 }


### PR DESCRIPTION
## Summary
- refactor the enrichment import endpoint to validate mapping configuration, stream rows safely, and batch insert records
- extract reusable helpers to normalize mapping definitions and sanitize CSV rows before database insertion
- add Bun unit tests covering mapping parsing and row-to-record conversion

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cd880f73e8832c9c93990816e33290